### PR TITLE
Add multiple receivers

### DIFF
--- a/dispatcher/main.go
+++ b/dispatcher/main.go
@@ -132,7 +132,7 @@ func monitor(run *models.Run, job *batchv1.Job) {
 		break
 	}
 
-	reportutils.Report(run)
+	reportutils.Report(run, droidMetadata.Receivers)
 }
 
 func queryTests(run *models.Run) []models.TaskSetting {

--- a/dispatcher/main.go
+++ b/dispatcher/main.go
@@ -132,7 +132,7 @@ func monitor(run *models.Run, job *batchv1.Job) {
 		break
 	}
 
-	reportutils.Report(run, droidMetadata.Receivers)
+	reportutils.Report(run, droidMetadata.Owners)
 }
 
 func queryTests(run *models.Run) []models.TaskSetting {

--- a/models/droidMetadata.go
+++ b/models/droidMetadata.go
@@ -14,7 +14,7 @@ type DroidMetadata struct {
 	Product      string                `yaml:"product"`
 	Storage      bool                  `yaml:"storage"`
 	Environments []DroidMetadataEnvDef `yaml:"environments"`
-	Receivers    []string              `yaml:"receivers"`
+	Owners       []string              `yaml:"owners"`
 }
 
 // DroidMetadataEnvDef defines the data model of the environment variable definition in metadata.yml

--- a/models/droidMetadata.go
+++ b/models/droidMetadata.go
@@ -14,6 +14,7 @@ type DroidMetadata struct {
 	Product      string                `yaml:"product"`
 	Storage      bool                  `yaml:"storage"`
 	Environments []DroidMetadataEnvDef `yaml:"environments"`
+	Receivers    []string              `yaml:"receivers"`
 }
 
 // DroidMetadataEnvDef defines the data model of the environment variable definition in metadata.yml

--- a/reportutils/report.go
+++ b/reportutils/report.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/Azure/adx-automation-agent/common"
 	"github.com/Azure/adx-automation-agent/models"
@@ -14,12 +15,26 @@ import (
 var httpClient = &http.Client{}
 
 // Report method requests the email service to send emails
-func Report(run *models.Run) {
+func Report(run *models.Run, receivers []string) {
 	common.LogInfo("Sending report...")
+
+	remark, ok := run.Settings[common.KeyRemark]
+	if ok && strings.ToLower(remark.(string)) == "official" {
+		for i := range receivers {
+			receivers[i] = fmt.Sprintf("%s@microsoft.com", receivers[i])
+		}
+	} else {
+		receivers = []string{}
+	}
+
 	if email, ok := run.Settings[common.KeyUserEmail]; ok {
+		receivers = append(receivers, email.(string))
+	}
+
+	if len(receivers) > 0 {
 		content := make(map[string]string)
 		content["run_id"] = strconv.Itoa(run.ID)
-		content["receivers"] = email.(string)
+		content["receivers"] = strings.Join(receivers, ", ")
 
 		body, err := json.Marshal(content)
 		if err != nil {

--- a/reportutils/report.go
+++ b/reportutils/report.go
@@ -34,7 +34,7 @@ func Report(run *models.Run, receivers []string) {
 	if len(receivers) > 0 {
 		content := make(map[string]string)
 		content["run_id"] = strconv.Itoa(run.ID)
-		content["receivers"] = strings.Join(receivers, ", ")
+		content["receivers"] = strings.Join(receivers, ",")
 
 		body, err := json.Marshal(content)
 		if err != nil {


### PR DESCRIPTION
To be able to send emails to all the team (using the `--remark official` flag in the client), it is expected to add the team's aliases to the metadata file.