### PR TITLE
Add the concept the status to the dispatcher

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,7 +9,10 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["proto","sortkeys"]
+  packages = [
+    "proto",
+    "sortkeys"
+  ]
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
   version = "v1.0.0"
 
@@ -21,7 +24,13 @@
 
 [[projects]]
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp"
+  ]
   revision = "925541529c1fa6821df4e44ce2723319eb2be768"
   version = "v1.0.0"
 
@@ -39,14 +48,21 @@
 
 [[projects]]
   name = "github.com/googleapis/gnostic"
-  packages = ["OpenAPIv2","compiler","extensions"]
+  packages = [
+    "OpenAPIv2",
+    "compiler",
+    "extensions"
+  ]
   revision = "ee43cbb60db7bd22502942cccbc39059117352ab"
   version = "v0.1.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/gregjones/httpcache"
-  packages = [".","diskcache"]
+  packages = [
+    ".",
+    "diskcache"
+  ]
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
 
 [[projects]]
@@ -105,6 +121,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/streadway/amqp"
+  packages = ["."]
+  revision = "d27ae102b8892a98ca4edb74539436af62577379"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   revision = "91a49db82a88618983a78a06c1cbd4e00ab749ab"
@@ -112,18 +134,41 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["http2","http2/hpack","idna","lex/httplex"]
+  packages = [
+    "http2",
+    "http2/hpack",
+    "idna",
+    "lex/httplex"
+  ]
   revision = "22ae77b79946ea320088417e4d50825671d82d57"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "dd2ff4accc098aceecb86b36eaa7829b2a17b1c9"
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
+  ]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
@@ -142,24 +187,136 @@
 [[projects]]
   branch = "master"
   name = "k8s.io/api"
-  packages = ["admissionregistration/v1alpha1","admissionregistration/v1beta1","apps/v1","apps/v1beta1","apps/v1beta2","authentication/v1","authentication/v1beta1","authorization/v1","authorization/v1beta1","autoscaling/v1","autoscaling/v2beta1","batch/v1","batch/v1beta1","batch/v2alpha1","certificates/v1beta1","core/v1","events/v1beta1","extensions/v1beta1","networking/v1","policy/v1beta1","rbac/v1","rbac/v1alpha1","rbac/v1beta1","scheduling/v1alpha1","settings/v1alpha1","storage/v1","storage/v1alpha1","storage/v1beta1"]
+  packages = [
+    "admissionregistration/v1alpha1",
+    "admissionregistration/v1beta1",
+    "apps/v1",
+    "apps/v1beta1",
+    "apps/v1beta2",
+    "authentication/v1",
+    "authentication/v1beta1",
+    "authorization/v1",
+    "authorization/v1beta1",
+    "autoscaling/v1",
+    "autoscaling/v2beta1",
+    "batch/v1",
+    "batch/v1beta1",
+    "batch/v2alpha1",
+    "certificates/v1beta1",
+    "core/v1",
+    "events/v1beta1",
+    "extensions/v1beta1",
+    "networking/v1",
+    "policy/v1beta1",
+    "rbac/v1",
+    "rbac/v1alpha1",
+    "rbac/v1beta1",
+    "scheduling/v1alpha1",
+    "settings/v1alpha1",
+    "storage/v1",
+    "storage/v1alpha1",
+    "storage/v1beta1"
+  ]
   revision = "7ebfdc5e7dfac82cc5c53e1259ad579915950e20"
 
 [[projects]]
   branch = "master"
   name = "k8s.io/apimachinery"
-  packages = ["pkg/api/errors","pkg/api/meta","pkg/api/resource","pkg/apis/meta/v1","pkg/apis/meta/v1/unstructured","pkg/apis/meta/v1beta1","pkg/conversion","pkg/conversion/queryparams","pkg/fields","pkg/labels","pkg/runtime","pkg/runtime/schema","pkg/runtime/serializer","pkg/runtime/serializer/json","pkg/runtime/serializer/protobuf","pkg/runtime/serializer/recognizer","pkg/runtime/serializer/streaming","pkg/runtime/serializer/versioning","pkg/selection","pkg/types","pkg/util/clock","pkg/util/errors","pkg/util/framer","pkg/util/intstr","pkg/util/json","pkg/util/net","pkg/util/runtime","pkg/util/sets","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/util/yaml","pkg/version","pkg/watch","third_party/forked/golang/reflect"]
+  packages = [
+    "pkg/api/errors",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1beta1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/clock",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/net",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/reflect"
+  ]
   revision = "e9ff529c66f83aeac6dff90f11ea0c5b7c4d626a"
 
 [[projects]]
   name = "k8s.io/client-go"
-  packages = ["discovery","kubernetes","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/admissionregistration/v1beta1","kubernetes/typed/apps/v1","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta2","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/events/v1beta1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/networking/v1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1alpha1","kubernetes/typed/storage/v1beta1","pkg/version","rest","rest/watch","tools/auth","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/reference","transport","util/cert","util/flowcontrol","util/homedir","util/integer"]
+  packages = [
+    "discovery",
+    "kubernetes",
+    "kubernetes/scheme",
+    "kubernetes/typed/admissionregistration/v1alpha1",
+    "kubernetes/typed/admissionregistration/v1beta1",
+    "kubernetes/typed/apps/v1",
+    "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v2beta1",
+    "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v1beta1",
+    "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/core/v1",
+    "kubernetes/typed/events/v1beta1",
+    "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/networking/v1",
+    "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/rbac/v1",
+    "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/scheduling/v1alpha1",
+    "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1alpha1",
+    "kubernetes/typed/storage/v1beta1",
+    "pkg/version",
+    "rest",
+    "rest/watch",
+    "tools/auth",
+    "tools/clientcmd",
+    "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
+    "tools/metrics",
+    "tools/reference",
+    "transport",
+    "util/cert",
+    "util/flowcontrol",
+    "util/homedir",
+    "util/integer"
+  ]
   revision = "78700dec6369ba22221b72770783300f143df150"
   version = "v6.0.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e5ee364726a6a9b8676e09df582ca69b4a3fde3e4bae6614c119c244535488e3"
+  inputs-digest = "8214115416b053d98d440acb58009844d1b37de2d9c00b48efbeea70b8293123"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,3 +36,7 @@
 [[constraint]]
   name = "k8s.io/client-go"
   version = "6.0.0"
+
+[[constraint]]
+  name = "github.com/streadway/amqp"
+  branch = "master"

--- a/common/data.go
+++ b/common/data.go
@@ -16,4 +16,5 @@ const (
 	KeyProduct         = "a01.reserved.product"
 	KeyAgentVersion    = "a01.reserved.agentver"
 	KeyRunID           = "a01.reserved.runid"
+	KeyJobName         = "a01.reserved.jobname"
 )

--- a/common/names.go
+++ b/common/names.go
@@ -14,6 +14,20 @@ const (
 	SecretNameAgents           = "agent-secrets"
 )
 
+const (
+	// RunStatusInitialized is set when a run is just created
+	RunStatusInitialized = "Initialized"
+
+	// RunStatusPublished is set when tasks are added to the task broker queue
+	RunStatusPublished = "Published"
+
+	// RunStatusRunning is set when test job is created and start running
+	RunStatusRunning = "Running"
+
+	// RunStatusCompleted is set when all tasks are accomplished
+	RunStatusCompleted = "Completed"
+)
+
 // GetCurrentNamespace returns the namespace this Pod belongs to. If it fails
 // to resolve the name, it uses the fallback name.
 func GetCurrentNamespace(fallback string) string {

--- a/models/run.go
+++ b/models/run.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os/exec"
+	"regexp"
 
 	"github.com/Azure/adx-automation-agent/common"
 	"github.com/Azure/adx-automation-agent/httputils"
@@ -15,6 +17,7 @@ type Run struct {
 	Name     string                 `json:"name"`
 	Settings map[string]interface{} `json:"settings"`
 	Details  map[string]string      `json:"details"`
+	Status   string                 `json:"status"`
 }
 
 // GetSecretName returns the secret mapping to this run.
@@ -28,14 +31,14 @@ func (run *Run) GetSecretName(metadata *DroidMetadata) string {
 	return metadata.Product
 }
 
-// Patch submit a patch
-func (run *Run) Patch() (*Run, error) {
+// SubmitChange POST the changes in current Run instance to task store
+func (run *Run) SubmitChange() (*Run, error) {
 	body, err := json.Marshal(run)
 	if err != nil {
 		return nil, fmt.Errorf("unable to marshal in JSON: %s", err.Error())
 	}
 
-	req, err := httputils.CreateRequest(http.MethodPatch, fmt.Sprintf("run/%d", run.ID), body)
+	req, err := httputils.CreateRequest(http.MethodPost, fmt.Sprintf("run/%d", run.ID), body)
 	if err != nil {
 		return nil, err
 	}
@@ -52,6 +55,53 @@ func (run *Run) Patch() (*Run, error) {
 	}
 
 	return &updated, nil
+}
+
+// QueryTests returns the list of test tasks based on the query string
+func (run *Run) QueryTests() []TaskSetting {
+	common.LogInfo(fmt.Sprintf("Expecting script %s.", common.PathScriptGetIndex))
+	content, err := exec.Command(common.PathScriptGetIndex).Output()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	var input []TaskSetting
+	err = json.Unmarshal(content, &input)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	if query, ok := run.Settings[common.KeyTestQuery]; ok {
+		common.LogInfo(fmt.Sprintf("Query string is '%s'", query))
+		result := make([]TaskSetting, 0, len(input))
+		for _, test := range input {
+			matched, regerr := regexp.MatchString(query.(string), test.Classifier["identifier"])
+			if matched && regerr == nil {
+				result = append(result, test)
+			}
+		}
+
+		return result
+	}
+
+	return input
+}
+
+// PrintInfo prints the run's detailed information to stdout
+func (run *Run) PrintInfo() {
+	common.LogInfo(fmt.Sprintf("Find run %d: %s.", run.ID, run.Name))
+	if run.Details != nil {
+		common.LogInfo("  Details")
+		for key, value := range run.Details {
+			common.LogInfo(fmt.Sprintf("    %s = %s", key, value))
+		}
+	}
+	if run.Settings != nil {
+		common.LogInfo("  Settings")
+		for key, value := range run.Settings {
+			common.LogInfo(fmt.Sprintf("    %s = %s", key, value))
+		}
+	}
 }
 
 // QueryRun returns the run of the runID

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -1,0 +1,74 @@
+package monitor
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/adx-automation-agent/common"
+	"github.com/Azure/adx-automation-agent/kubeutils"
+	"github.com/Azure/adx-automation-agent/models"
+	"github.com/Azure/adx-automation-agent/schedule"
+)
+
+const (
+	interval = time.Second * 30
+)
+
+var (
+	namespace = common.GetCurrentNamespace("a01-prod")
+	clientset = kubeutils.TryCreateKubeClientset()
+)
+
+// WaitTasks blocks the caller till the job finishes.
+func WaitTasks(taskBroker *schedule.TaskBroker, run *models.Run) {
+	common.LogInfo("Begin monitoring task execution ...")
+
+	ch, err := taskBroker.GetChannel()
+	common.PanicOnError(err, "Fail to establish channel to the task broker during monitoring.")
+
+	jobName := run.Details[common.KeyJobName]
+	podListOpt := metav1.ListOptions{LabelSelector: fmt.Sprintf("job-name=%s", jobName)}
+	api := clientset.CoreV1()
+
+	for {
+		time.Sleep(interval)
+
+		queue, err := ch.QueueInspect(jobName)
+		if err != nil {
+			common.LogWarning(fmt.Errorf("Fail to insepct the queue %s: %s", jobName, err).Error())
+			continue
+		}
+		common.LogInfo(fmt.Sprintf("Queue: messages %d.", queue.Messages))
+
+		if queue.Messages != 0 {
+			// there are tasks to be run
+			continue
+		}
+
+		// the number of the message in the queue is zero. make sure all the
+		// pods in this job have finished
+		podList, err := api.Pods(namespace).List(podListOpt)
+		if err != nil {
+			common.LogWarning(fmt.Errorf("Fail to list pod of %s: %s", jobName, err).Error())
+			continue
+		}
+
+		runningPods := 0
+		for _, pod := range podList.Items {
+			if pod.Status.Phase == corev1.PodRunning {
+				runningPods++
+			}
+		}
+
+		if runningPods != 0 {
+			common.LogInfo(fmt.Sprintf("%d pod are still running.", runningPods))
+			continue
+		}
+
+		// zero task in the queue and all pod stop.
+		break
+	}
+}


### PR DESCRIPTION
The dispatcher now understands the concept of run status and will act
differently based on the current status of the run. This will prevent a
dispatcher from repeatedly publishing jobs to the queue after it crashes
and restarted by the Kubernetes.

Additionally, in this commit, major refactory is done to the dispatcher
to move logic closer to the data models.